### PR TITLE
Update fate.html

### DIFF
--- a/Fate_Accelerated/fate.html
+++ b/Fate_Accelerated/fate.html
@@ -1,7 +1,7 @@
 <div class='sheet-2colrow'>
     <div class="sheet-col-id sheet-col">
-        <div class="sheet-header">ID</div>
-        <label>Name <input type="text" name="attr_name"  placeholder="Name" title="@{name}"/></label>
+        <div class="sheet-header">Name</div>
+        <input type="text" name="attr_name"  placeholder="Name" title="@{name}"/>
         <textarea name="attr_description"  placeholder="Description" title="@{description}"></textarea>
     </div> <!-- .section-id -->
 
@@ -33,34 +33,38 @@
         <table class="sheet-approaches">
             <tbody>
             <tr>
-                <td><button type='roll' value='/roll 4dF + @{careful}' name='roll_careful' /></td>
+                <td><button type='roll' value='&{template:FAE} {{name=@{name}}} {{approach=Careful}} {{roll=[[4DF+@{careful}]]}}' name='roll_careful' /></td>
                 <td><label>Careful</label></td>
                 <td><input type="number" name="attr_careful" title="@{careful}"/></td>
             </tr>
             <tr>
-                <td><button type='roll' value='/roll 4dF + @{clever}' name='roll_clever' /></td>
+                <td><button type='roll' value='&{template:FAE} {{name=@{name}}} {{approach=Clever}} {{roll=[[4DF+@{clever}]]}}' name='roll_clever' /></td>
                 <td><label>Clever</label></td>
                 <td><input type="number" name="attr_clever" title="@{clever}"/></td>
             </tr>
             <tr>
-                <td><button type='roll' value='/roll 4dF + @{flashy}' name='roll_flashy' /></td>
+                <td><button type='roll' value='&{template:FAE} {{name=@{name}}} {{approach=Flashy}} {{roll=[[4DF+@{flashy}]]}}' name='roll_flashy' /></td>
                 <td><label>Flashy</label></td>
                 <td><input type="number" name="attr_flashy" title="@{flashy}"/></td>
             </tr>
             <tr>
-                <td><button type='roll' value='/roll 4dF + @{forceful}' name='roll_forceful' /></td>
+                <td><button type='roll' value='&{template:FAE} {{name=@{name}}} {{approach=Forceful}} {{roll=[[4DF+@{forceful}]]}}' name='roll_forceful' /></td>
                 <td><label>Forceful</label></td>
                 <td><input type="number" name="attr_forceful" title="@{forceful}"/></td>
             </tr>
             <tr>
-                <td><button type='roll' value='/roll 4dF + @{quick}' name='roll_quick' /></td>
+                <td><button type='roll' value='&{template:FAE} {{name=@{name}}} {{approach=Quick}} {{roll=[[4DF+@{quick}]]}}' name='roll_quick' /></td>
                 <td><label>Quick</label></td>
                 <td><input type="number" name="attr_quick" title="@{quick}"/></td>
             </tr>
             <tr>
-                <td><button type='roll' value='/roll 4dF + @{sneaky}' name='roll_sneaky' /></td>
+                <td><button type='roll' value='&{template:FAE} {{name=@{name}}} {{approach=Sneaky}} {{roll=[[4DF+@{sneaky}]]}}' name='roll_sneaky' /></td>
                 <td><label>Sneaky</label></td>
                 <td><input type="number" name="attr_sneaky" title="@{sneaky}"/></td>
+            </tr>
+            <tr>
+                <td><button type='roll' value='&{template:FAE}{{name=@{name}}}{{effect=?{Approach|Careful, Careful: [[4DF+ @{careful}]]|Clever, Clever: [[4DF+ @{clever}]]|Flashy, Flashy: [[4DF+ @{flashy}]]|Forceful,Forceful: [[4DF+ @{forceful}]]|Quick,Quick: [[4DF+ @{quick}]]|Sneaky,Sneaky: [[4DF+ @{sneaky}]]}}}' name='roll_approachesy' /></td>
+                <td><label>Approaches</label></td>
             </tr>
             </tbody>
         </table>
@@ -81,7 +85,7 @@
         <div class="sheet-header">Consequences</div>
         <fieldset class="repeating_consequences">
             <input type="text" name="attr_consequence" />
-			<select name="attr_consequences_type">
+    		<select name="attr_consequences_type">
 				<option value="2">Mild(-2)</option>
 				<option value="4">Moderate(-4)</option>
 				<option value="6">Severe(-6)</option>
@@ -133,3 +137,21 @@
         <textarea name="attr_Extras"></textarea>
     </div> <!-- .section-extra -->
 </div>
+
+<rolltemplate class="sheet-rolltemplate-FAE">
+    <table>
+    	<tr><th>{{name}}</th></tr>
+		{{#approach}}
+			<tr><th>{{approach}}</th></tr>
+		{{/approach}}
+	
+		<tr class="arrow-container"><td><div class="arrow-right"></div></td></tr>		
+
+		{{#roll}}
+			<tr><td><span class="tcat">Roll: </span>{{roll}}</td></tr>
+		{{/roll}}
+		{{#effect}}
+			<tr><td><span class="tcat">Effect: </span>{{effect}}</td></tr>
+		{{/effect}}
+    </table>
+</rolltemplate>


### PR DESCRIPTION
Added a simple roll template: FAE
    fields are name, approach, roll, effect. approach, roll, and effect are not displayed if left blank

modified the approach buttons to use the roll template
added an additional roll button "Approaches' which uses an drop down query to allow the user to only need one button in the macro bar for all of their approaches
